### PR TITLE
Add simple user feedback on payload attempt using LEDs.

### DIFF
--- a/files/20-tegra_rcm
+++ b/files/20-tegra_rcm
@@ -8,5 +8,11 @@ APX_PRODID="955/7321/102"
 if [ "${ACTION}" = "add" ]; then
     if [ "${PRODUCT}" = "${APX_PRODID}" ]; then
         ${BINARY}
+        echo 0 > /sys/class/leds/a5-v11\:red\:power/brightness
+        for i in 1 0 ; do
+                echo -n $i > /sys/class/leds/a5-v11\:blue\:system/brightness
+                sleep 1
+        done
+        echo 255 > /sys/class/leds/a5-v11\:red\:power/brightness
     fi
 fi


### PR DESCRIPTION
There is currently no way to know if the console has successfully passed into RCM mode, so this will tell the user that the device was detected properly and an attempt has been made to run the payload script. The LED device paths appear to be standard for the build target. An LED value of 255 is what is reported by the device by default, but either 0 or 1 will suffice for setting/clearing the LED.