### PR TITLE
Add Nix flake for fusee-nano

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "fusee-nano - A minimalist re-implementation of the Fusée Gelée exploit";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          fusee-nano = pkgs.stdenv.mkDerivation {
+            pname = "fusee-nano";
+            version = "0.5.3";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [
+              xxd
+              gcc
+              gnumake
+            ];
+
+            buildPhase = ''
+              make
+            '';
+
+            installPhase = ''
+              make install PREFIX=$out/bin
+            '';
+
+            meta = with pkgs.lib; {
+              description = "A minimalist re-implementation of the Fusée Gelée exploit, designed to run on embedded Linux devices. (Zero dependencies)";
+              license = licenses.mit;
+              platforms = platforms.linux;
+            };
+          };
+
+          default = self.packages.${system}.fusee-nano;
+        };
+
+        apps = {
+          fusee-nano = {
+            type = "app";
+            program = "${self.packages.${system}.fusee-nano}/bin/fusee-nano";
+          };
+
+          default = self.apps.${system}.fusee-nano;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            xxd
+            gcc
+            gnumake
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Description
This pull request introduces a Nix flake for the `fusee-nano` project, enabling reproducible builds, packaging, and development environments using Nix. The new `flake.nix` file defines how to build, install, and use the `fusee-nano` application across different systems.

## Changes Made
- Added a `flake.nix` file that:
  - Defines the project as a Nix flake with metadata and dependencies (`nixpkgs`, `flake-utils`).
  - Provides a `fusee-nano` package derivation with build and install phases, specifying required build tools (`xxd`, `gcc`, `gnumake`).
  - Exposes the `fusee-nano` binary as a Nix flake app for easy execution.
  - Adds a development shell (`devShells.default`) with necessary build inputs for contributors.

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Build system enhancement

## How to Test
1. **Run the flake app**:
 - Before merge
 ```bash
   nix run github:EniumRaphael/fusee-nano#fusee-nano-flake
 ```
 - After Merge
  ```bash
   nix run github:DavidBuchanan314/fusee-nano#fusee-nano
 ```